### PR TITLE
[Fix] Fix page title

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="pt-br">
   <head>
-    <title>PHPeste 2022 - Natal, capital RN</title>
+    <title>PHPeste 2023 - Fortaleza, capital do Ceará</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 


### PR DESCRIPTION
A página está com "PHPeste _2022_ - _Natal_, capital _RN_" como título no momento (escapou 😅).